### PR TITLE
Don't require table:columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* The `table:columns` field is no longer required on `Item`
+- The `table:columns` field is no longer required on `Item`
 
 ## [v1.0.0] - 2021-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [v1.0.1] - 2021-08-30
+
+### Changed
+
+* The `table:columns` field is no longer required on `Item`
+
 ## [v1.0.0] - 2021-08-27
 
 Initial release.
 
 [Unreleased]: <https://github.com/stac-extensions/table/compare/v1.0.0...HEAD>
+[v1.0.1]: <https://github.com/stac-extensions/table/tree/v1.0.1>
 [v1.0.0]: <https://github.com/stac-extensions/table/tree/v1.0.0>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Additionally, Collections can describe many tabular datasets using [Table object
 
 |       Field Name       |                Type                 |                            Description                            |
 | ---------------------- | ----------------------------------- | ----------------------------------------------------------------- |
-| table:columns          | [ [Column Object](#column-object) ] | **REQUIRED**. A list of (#column objects) describing each column. |
+| table:columns          | [ [Column Object](#column-object) ] | A list of (#column objects) describing each column. |
 | table:primary_geometry | string                              | The primary geometry column name.                                 |
 | table:row_count        | number                              | The number of rows in the dataset.                                |
 

--- a/examples/table-collection.json
+++ b/examples/table-collection.json
@@ -48,21 +48,15 @@
       "maximum": "2019-07-10T13:44:56Z"
     }
   },
-  "table:columns": [
+  "table:tables": [
     {
-      "name": "geometry",
-      "description": "The observation location.",
-      "type": "int64"
+      "name": "first table",
+      "description": "This is my first table"
     },
     {
-      "name": "id",
-      "description": "The numerical identifier"
-    },
-    {
-      "name": "value"
+      "name": "Second table"
     }
   ],
-  "table:primary_geometry": "geometry",
   "links": [
     {
       "href": "https://example.com/examples/collection.json",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -25,9 +25,7 @@
               "allOf": [
                 {
                   "$comment": "Require fields here for Item Properties.",
-                  "required": [
-                    "table:columns"
-                  ]
+                  "required": []
                 },
                 {
                   "$ref": "#/definitions/fields"
@@ -69,9 +67,7 @@
           "allOf": [
             {
               "$comment": "Require fields here for Collections (top-level).",
-              "required": [
-                "table:columns"
-              ]
+              "required": []
             },
             {
               "$ref": "#/definitions/fields"
@@ -161,9 +157,7 @@
       "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
       "anyOf": [
         {
-          "required": [
-            "table:columns"
-          ]
+          "required": []
         }
       ]
     },


### PR DESCRIPTION
This makes it easier to use the `table` extension on a Collection where you only wish to document the tables available.